### PR TITLE
docs: fix integrations option name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To customize the SDK further, additional parameters can be passed to the `init()
 | `proxy`                    | An object representing configuration for routing all SDK network requests through a custom proxy server.                                                                                   | No           | array     | See [Proxy](#proxy) section |
 | `storage`                    | Custom storage connector for persisting user decisions and campaign data.                                                                                   | No           | array     | See [Storage](#storage) section |
 | `logger`                     | Toggle log levels for more insights or for debugging purposes. You can also customize your own transport in order to have better control over log messages. | No           | array     | See [Logger](#logger) section   |
-| `Integrations`         | Callback function for integrating with third-party analytics services.                                              | No           | object      | See [Integrations](#integrations) section |
+| `integrations`         | Callback function for integrating with third-party analytics services.                                              | No           | object      | See [Integrations](#integrations) section |
 
 Refer to the [official VWO documentation](https://developers.vwo.com/v2/docs/fme-php-install) for additional parameter details.
 


### PR DESCRIPTION
## Summary
This PR fixes a documentation mismatch in the README's advanced configuration table.

## What changed
- Changed `Integrations` to `integrations` in the advanced options table
- Kept the docs consistent with the example usage and actual SDK option name

## Why
The old capitalization could confuse users into passing the wrong config key.

## Verification
- Confirmed the repo test suite passes locally before the docs change
