### PR TITLE
docs: clarify proxy default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ $vwoClient = VWO::init([
     'accountId' => 123456,
     'proxy' => [
         'url' => 'http://custom.proxy.com',
-        'isUrlNotSecure' => false // be default, it should be true
+        'isUrlNotSecure' => false // by default, it should be false
     ],
 ]);
 ```


### PR DESCRIPTION
I noticed the proxy example in the README had a comment that didn't match the table below it. The comment said `isUrlNotSecure` should be `true` by default, but the table says the default is `false` when using HTTPS. I updated the comment so the docs are consistent and anyone setting up proxy support doesn't get mixed signals.
